### PR TITLE
deconz should handle the reset timer

### DIFF
--- a/device-config-schema.coffee
+++ b/device-config-schema.coffee
@@ -1,7 +1,7 @@
 module.exports = {
   title: "raspbee"
   RaspBeeSystem: {
-    title: "Controle Center Device properties"
+    title: "Control Center Device properties"
     type: "object"
     extensions: ["xLink"]
     properties:
@@ -20,9 +20,9 @@ module.exports = {
         type: "string"
         required: true
       resetTime:
-        description: "Optional auto reset time in milli seconds"
+        description: "Reset time in seconds"
         type: "integer"
-        default: 0
+        default: 60
         required: false
       sensorIDs:
         description: "All the ids of the sensors"

--- a/raspbee-connector.coffee
+++ b/raspbee-connector.coffee
@@ -125,6 +125,21 @@ module.exports = (env) ->
           return Promise.reject("Bad request")
       )
 
+    setSensorConfig: (id,param) =>
+      options = {
+        uri: 'http://'+@host+':'+@port+'/api/'+@apikey+'/sensors/'+id+'/config',
+        method: 'PUT',
+        body: JSON.stringify(param)
+      }
+      Request(options).then( (res) =>
+        return JSON.parse(res)
+      ).catch ( (err) =>
+        if (err.statusCode is 404)
+          return Promise.reject("Device not found")
+        else
+          return Promise.reject("Bad request")
+      )
+
     setGroupScene: (id, scene_id) =>
       options = {
         uri: 'http://'+@host+':'+@port+'/api/'+@apikey+'/groups/'+id+'/scenes/'+scene_id+'/recall',

--- a/raspbee.coffee
+++ b/raspbee.coffee
@@ -306,15 +306,18 @@ module.exports = (env) ->
         if @sensorIDs.length
           for id in @sensorIDs
             myRaspBeePlugin.Connector.getSensor(id).then( (res) =>
+              if res.config?.duration?
+                @_setDuration(id)
               @_updateAttributes res
             )
         else
           myRaspBeePlugin.Connector.getSensor(@deviceID).then( (res) =>
+            if res.config?.duration?
+              @_setDuration(@deviceID)
             @_updateAttributes res
           )
 
     destroy: ->
-      clearTimeout(@_resetTimeout) if @_resetTimeout?
       super()
 
     _setBattery: (value) ->
@@ -328,18 +331,23 @@ module.exports = (env) ->
       @emit 'lux', value
 
     _setMotion: (value) ->
-      clearTimeout(@_resetTimeout)
       @_setPresence(value)
-      if (@config.resetTime > 0) and (value = true)
-        @_resetTimeout = setTimeout(( =>
-          @_setPresence(false)
-        ), @config.resetTime)
 
     _setOnline: (value) ->
       if @_online is value then return
       @_online = value
       @emit 'online', value
 
+    _setDuration: (id) ->
+      duration = @config.resetTime
+      if duration < 60
+        duration = 60
+      config = {
+        duration: duration
+      }
+      myRaspBeePlugin.Connector.setSensorConfig(id, config).then( (res) =>
+
+      )
     getOnline: -> Promise.resolve(@_online)
 
     getLux: -> Promise.resolve @_lux


### PR DESCRIPTION
Deconz has an option to change the config for certain sensors. We can adjust the duration of the pir with it. So instead of using a timer in the motion device, let it be handled by the deconz api.