### PR TITLE
Added option to ratelimit device updates

### DIFF
--- a/device-config-schema.coffee
+++ b/device-config-schema.coffee
@@ -319,6 +319,10 @@ module.exports = {
         description: "Auto reset time in milliseconds"
         type: "integer"
         default: 1000
+      rateLimit:
+        description: "Limit data updates to on once every x milliseconds (0 for no limit)"
+        type: "integer"
+        default: 0
   },
   RaspBeeGroupScenes: {
     title: "RaspBeeScenes"


### PR DESCRIPTION
I've had issues with my Pimatic install getting flooded by power sensors, so I've implemented an optional ratelimit option for MultiSensor devices